### PR TITLE
add "npm cache clean --force" to DockerfileArm

### DIFF
--- a/DockerfileArm
+++ b/DockerfileArm
@@ -1,6 +1,7 @@
 FROM node:14 AS build-frontend
 
 COPY appwidgets appwidgets
+RUN npm cache clean --force
 RUN cd appwidgets && \
     npm install yarn && \
     yarn build:prod

--- a/DockerfileArm
+++ b/DockerfileArm
@@ -2,6 +2,7 @@ FROM node:14 AS build-frontend
 
 COPY appwidgets appwidgets
 RUN npm cache clean --force
+RUN npm cache verify
 RUN cd appwidgets && \
     npm install yarn && \
     yarn build:prod


### PR DESCRIPTION
Adding 'RUN npm cache clean --force' before step 3 in DockerfileArm to avoid "npm ERR! cb() never called!" error.
This solves #18 