### PR TITLE
Minor fixes for demo

### DIFF
--- a/qoffee.ipynb
+++ b/qoffee.ipynb
@@ -327,7 +327,7 @@
     "        result = execute(mqc, backend_ideal).result()\n",
     "        # get state vector and calculate probabilities\n",
     "        state_vector = result.get_statevector(mqc, decimals=5)\n",
-    "        probs = state_vector.probabilities()\n",
+    "        probs = state_vector.probabilities() if hasattr(state_vector, \"probabilities\") else np.abs(state_vector ** 2)\n",
     "        # map back to bit configurations\n",
     "        results = {\n",
     "            key: probs[i] for i, key in enumerate(CircuitExecutor.BIT_ORDER)\n",

--- a/qoffeeapi/qoffeeapi/oauth2.py
+++ b/qoffeeapi/qoffeeapi/oauth2.py
@@ -51,7 +51,7 @@ class OAuth2Connector:
         Refresh the current access_token using the refresh_token, if available
         """
         if not self.tokens or 'refresh_token' not in self.tokens:
-            return {'error': True, 'error_description': 'no refresh token set'}
+            return 401, {'error': 'no refresh token set'}
         data = {'grant_type': 'refresh_token', 'refresh_token': self.tokens['refresh_token']}
         access_token_response = requests.post(self.token_url, data=data, verify=False, allow_redirects=False, auth=(self.client_id, self.client_secret))
         return self._parse_access_token_response(access_token_response)

--- a/qoffeefrontend/app.js
+++ b/qoffeefrontend/app.js
@@ -87,6 +87,15 @@ define([
      */
     function refreshAuth() {
         console.log("Start refreshing auth key")
+
+        function setAuthStatus(success) {
+            const color = (success) ? 'green' : 'red';
+            document.getElementById('refreshauth-button-container').style.backgroundColor = color;
+            setTimeout(() => {
+                document.getElementById('refreshauth-button-container').style.backgroundColor = null;
+            }, 2000);
+        }
+
         return new Promise((resolve, reject) => {
             // do POST request to Jupyter backend
             fetch("/auth/refresh", {
@@ -98,12 +107,14 @@ define([
             }).then(response => {
                 // if fail, alert and go to welcome
                 if(!response.ok) {
+                    setAuthStatus(false);
                     alert("Could not refresh auth");
                     window.open('/auth', '_blank');
                     reject();
                 }
                 // if succeed to to success
                 else {
+                    setAuthStatus(true);
                     resolve();
                 }
             }, error => {


### PR DESCRIPTION
These commits contain two fixes:
- Fix an internal server error when /auth/refresh is called without calling /auth before. This will return a 401 now and redirect to login page. In addition, there is a visual feedback to the button _Refresh Auth_
- Fix a problem with state_vector. In former Qiskit versions, this used to be a numpy array, now it is a `StateVector` object. To keep backwards compatibility, we check if it has a `.probabilities()` method and if not treat it as a numpy array