### PR TITLE
Show link on help page and handle fullscreen

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 qoffeeapi/qoffeeapi.egg-info
 qoffeeapi/__pycache__
+
+appwidgets/node_modules

--- a/qoffee.ipynb
+++ b/qoffee.ipynb
@@ -673,7 +673,7 @@
     "        <div id=\"navigation-container\">\n",
     "            <button id=\"navigation-button-q\" data-device=\"${single_shot_device}\" data-rh-exec='set_next_single_shot_device()'>Q</button>\n",
     "            <button id=\"navigation-button-back\" data-rh-if=\"${view} != 'welcome'\" class=\"navigation-button\" data-rh-exec=\"load_welcome()\">&#5130;</button>\n",
-    "            <button id=\"navigation-button-help\" data-rh-exec-js='window.openQRCode(\"http://qoffee-maker.org\", \"http://qoffee-maker.org\")'>?</button>\n",
+    "            <button id=\"navigation-button-help\" data-rh-exec-js='window.openHelp()'>?</button>\n",
     "        </div>\n",
     "    </div>\n",
     "\"\"\", data_model=data)\n",
@@ -1190,34 +1190,34 @@
        },
        "heading": "Qoffee Maker powered by <b>IBM Quantum</b>",
        "histogram_anal": {
-        "000": 0.12499760249999999,
-        "001": 0.12499760249999999,
-        "010": 0.12499760249999999,
-        "011": 0.12499760249999999,
         "100": 0.12499760249999999,
         "101": 0.12499760249999999,
         "110": 0.12499760249999999,
-        "111": 0.12499760249999999
+        "111": 0.12499760249999999,
+        "000": 0.12499760249999999,
+        "001": 0.12499760249999999,
+        "010": 0.12499760249999999,
+        "011": 0.12499760249999999
        },
        "histogram_mock": {
-        "000": 0,
-        "001": 0,
-        "010": 0,
-        "011": 0,
         "100": 0,
         "101": 0,
         "110": 0,
-        "111": 0
+        "111": 0,
+        "000": 0,
+        "001": 0,
+        "010": 0,
+        "011": 0
        },
        "histogram_qasm": {
-        "000": 0.11875,
-        "001": 0.09625,
-        "010": 0.12625,
-        "011": 0.12375,
         "100": 0.1325,
         "101": 0.1325,
         "110": 0.13375,
-        "111": 0.13625
+        "111": 0.13625,
+        "000": 0.11875,
+        "001": 0.09625,
+        "010": 0.12625,
+        "011": 0.12375
        },
        "qasm": "OPENQASM 2.0;\ninclude \"qelib1.inc\";\nqreg q[3];\ncreg c[3];\nh q[0];\nh q[1];\nh q[2];\n",
        "show_mock_results": false,
@@ -1462,34 +1462,34 @@
        },
        "heading": "Qoffee Maker powered by <b>IBM Quantum</b>",
        "histogram_anal": {
-        "000": 0,
-        "001": 0,
-        "010": 0,
-        "011": 0,
         "100": 0,
         "101": 0,
         "110": 0,
-        "111": 0
+        "111": 0,
+        "000": 0,
+        "001": 0,
+        "010": 0,
+        "011": 0
        },
        "histogram_mock": {
-        "000": 0,
-        "001": 0,
-        "010": 0,
-        "011": 0,
         "100": 0,
         "101": 0,
         "110": 0,
-        "111": 0
+        "111": 0,
+        "000": 0,
+        "001": 0,
+        "010": 0,
+        "011": 0
        },
        "histogram_qasm": {
-        "000": 0,
-        "001": 0,
-        "010": 0,
-        "011": 0,
         "100": 0,
         "101": 0,
         "110": 0,
-        "111": 0
+        "111": 0,
+        "000": 0,
+        "001": 0,
+        "010": 0,
+        "011": 0
        },
        "qasm": "",
        "show_mock_results": false,

--- a/qoffeefrontend/app.css
+++ b/qoffeefrontend/app.css
@@ -124,6 +124,9 @@ body.app-mode .emergency-button-container {
 #refreshauth-button-container {
 	right: 75px;
 }
+#fullscreen-button-container {
+	right: 180px;
+}
 
 #restart-overlay {
 	background-color: rgba(0, 0, 0, 0.8); 
@@ -171,14 +174,41 @@ body.app-mode .emergency-button-container {
 	border-style: solid;
 	border-width: 20px;
 }
-#qrcode-container a {
+#qrcode-container a.qrcode-link {
 	text-align: center;
 }
-#qrcode-container p {
+#qrcode-container p.qrcode-text {
 	font-size: 2em;
 	color: white;
 	width: 100%;
 	text-align: center;
 	margin-top: 15px;
 	margin-bottom: 20px;
+}
+
+#qrcode-container a.help-link {
+	width: 450px;
+	left: 50%;
+	margin-left: -225px;
+	position: relative;
+	cursor: pointer;
+	padding: 10px 10px 4em 10px;
+	color: black;
+	font-size: 1.7em;
+	background-color: #e0e0e0;
+	margin-bottom: 20px;
+}
+#qrcode-container a.help-link:hover {
+	text-decoration: none;
+}
+#qrcode-container a.help-link:last-of-type {
+	margin-bottom: 0;
+}
+
+#qrcode-container a.help-link span.arrow {
+	color: rgba(40, 105, 245);
+    position: absolute;
+    bottom: 10px;
+    left: 20px;
+    font-size: 1.5em;
 }

--- a/qoffeefrontend/app.js
+++ b/qoffeefrontend/app.js
@@ -22,6 +22,14 @@ define([
         $(".app-view").removeClass("selected");
     }
 
+    function goFullscreen() {
+        document.documentElement.requestFullscreen().then(_ => {
+            console.log("Fullscreen started");
+        }, error => {
+            console.log("Fullscreen rejected");
+        });
+    }
+
     /**
      * Activate the app mode, build viewId index and initialize event listeners
      * @function activateApp
@@ -45,6 +53,9 @@ define([
         });
         // disable selection of cells
         $(jupyter.events).on("select.Cell", handleCellSelection);
+
+        goFullscreen();
+
         // automatically restart
         restart();
     }
@@ -203,6 +214,38 @@ define([
     }
 
     /**
+     * Close fullscreen
+     * @function closeFullscreen
+     */
+    function closeFullscreen() {
+        // close full screen if activated
+        try {
+            const exitFullscreenFn = document.exitFullscreen
+            || document.webkitExitFullscreen
+            || document.mozCancelFullScreen
+            || document.msExitFullscreen
+            exitFullscreenFn.call(document);
+        } catch (error) {
+            console.info("Not able to close fullscreen, fail silently")
+        }
+        return true;
+    }
+
+    /**
+     * Open Help Overlay
+     * @function openHelp
+     */
+    function openHelp() {
+        // clear previous qr code
+        $("#qrcode-container").empty();
+        $("#qrcode-container").append(`
+            <a class="help-link" target="_blank" onclick="window.myCloseFullscreen()" href="http://qoffee-maker.org">Qoffee Maker<br/><i>http://qoffee-maker.org</i><span class="arrow">→</span><a/>
+            <a class="help-link" target="_blank" onclick="window.myCloseFullscreen()" href="http://quantum-computing.ibm.com">IBM Quantum<br/><i>http://quantum-computing.ibm.com</i><span class="arrow">→</span><a/>
+        `)
+        $("#qrcode-container").addClass("active");
+    }
+
+    /**
      * Open an overlay which displays a QR Code
      * @function openQRCode
      * @param {string} url URL to encode into a QR Code
@@ -210,9 +253,8 @@ define([
      */
     function openQRCode(url, text="") {
         // clear previous qr code
-        $("#qrcode").empty();
-        $("#qrcode-container a").remove();
-        $("#qrcode-container p").remove();
+        $("#qrcode-container").empty();
+        $("#qrcode-container").append('<div id="qrcode"></div>');
         // create qrcode
         const qrcode = new QRCode(document.getElementById("qrcode"), {
             text: url,
@@ -225,7 +267,7 @@ define([
         if(text != "") {
             $("#qrcode-container").prepend('<p class="qrcode-text">'+text+'</p>')
         }
-        $("#qrcode-container").append('<a href="'+url+'" target="_blank">Open</a>')
+        $("#qrcode-container").append('<a class="qrcode-link" href="'+url+'" target="_blank">Open</a>')
     }
 
     /**
@@ -291,6 +333,8 @@ define([
         window.requestDrink = requestDrink
         window.openQRCodeIBMQ = openQRCodeIBMQ
         window.openQRCode = openQRCode
+        window.openHelp = openHelp
+        window.myCloseFullscreen = closeFullscreen
         window.refreshAuth = refreshAuth
         window.activateCoffeeMachine = activateCoffeeMachine
 
@@ -308,11 +352,15 @@ define([
         $("body").append('<div id="refreshauth-button-container" class="emergency-button-container"><button type="button" id="refreshauth-button">Refresh Auth</button></div>')
         $(document).on("click", "#refreshauth-button", refreshAuth);
 
+        // add a button to UI to go fullscreen
+        $("body").append('<div id="fullscreen-button-container" class="emergency-button-container"><button type="button" id="fullscreen-button">Fullscreen</button></div>')
+        $(document).on("click", "#fullscreen-button", goFullscreen);
+
         /*
             Add QR Code Container
         */
         // add container to render QRCode
-        $('body').append('<div id="qrcode-container"><div id="qrcode"></div></div>');
+        $('body').append('<div id="qrcode-container"></div>');
         // add listener to close on click
         $("#qrcode-container").on("click", "*", event => {
             $("#qrcode-container").removeClass("active");


### PR DESCRIPTION
The help page shows two links now instead of the QR code.

The app goes fullscreen automatically and leaves fullscreen on opening a link from Help page. There is another button on bottom-right to go back to fullscreen.


<img width="1792" alt="image" src="https://user-images.githubusercontent.com/18496236/170589485-6db28257-97d2-4645-b69d-1816b3657a4c.png">
