### PR TITLE
Add Fun with Quantum family footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    {% include head-custom.html %}
+
+{% seo %}
+  </head>
+
+  <body>
+
+    <header>
+      <div class="container">
+        <a id="a-title" href="{{ '/' | relative_url }}">
+          <h1>{{ site.title | default: site.github.repository_name }}</h1>
+        </a>
+        <h2>{{ site.description | default: site.github.project_tagline }}</h2>
+
+        <section id="downloads">
+          {% if site.show_downloads %}
+            <a href="{{ site.github.zip_url }}" class="btn">Download as .zip</a>
+            <a href="{{ site.github.tar_url }}" class="btn">Download as .tar.gz</a>
+          {% endif %}
+          <a href="{{ site.github.repository_url }}" class="btn btn-github"><span class="icon"></span>View on GitHub</a>
+        </section>
+      </div>
+    </header>
+
+    <div class="container">
+      <section id="main_content">
+        {{ content }}
+      </section>
+    </div>
+
+    <style>
+      .family-footer {
+        margin: 40px 0 20px;
+        padding-top: 16px;
+        border-top: 1px dashed #666;
+        text-align: center;
+        font-size: 13px;
+        color: #999;
+      }
+      .family-footer div { margin: 6px 0; }
+      .family-footer .tagline {
+        color: #b5e853;
+        letter-spacing: .08em;
+        font-size: 12px;
+      }
+    </style>
+    <footer class="container family-footer">
+      <div class="tagline">GOD DOES PLAY DICE. COME PLAY, BUILD, LEARN.</div>
+      <div><strong>Part of the Fun with Quantum family:</strong>
+        <a href="https://fun-with-quantum.org">Fun with Quantum</a> ·
+        <a href="https://rasqberry.org">RasQberry Two</a> ·
+        <a href="https://rasqberry.one">RasQberry One</a> ·
+        <a href="https://quantego.org">Quantego</a> ·
+        <a href="https://qutie.org">Qutie</a>
+      </div>
+      <div>Open source, built by <a href="https://www.linkedin.com/in/JanLahmann">Jan-R. Lahmann</a> and the RasQberry community.</div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
Adds the shared "Fun with Quantum family" footer for cross-traffic across the family sites, matching the footers already live on fun-with-quantum.org and qutie.org.

**What changed**
- New `_layouts/default.html`: a verbatim copy of the jekyll-theme-hacker default layout with a `<footer class="family-footer">` appended before `</body>` — tagline, links to the sibling sites (Fun with Quantum, RasQberry Two, RasQberry One, Quantego, Qutie — Qoffee-Maker itself excluded), and the "Open source, built by Jan-R. Lahmann and the RasQberry community" credit line, styled to match the theme (dashed divider, green tagline `#b5e853`, muted grey text).

Overriding the layout is the documented GitHub Pages theme-customization path and is the only way to get the footer on **all** pages of this multi-page site (index, Composer, Gates, instructions, exercises), since the theme layout has no footer hook. GitHub Pages' `jekyll-default-layout` plugin applies this layout to every markdown page.

**How verified**
- Compared the copied layout against the live HTML served at qoffee-maker.org: identical structure (head-custom include, SEO tag, header, `#main_content`), so the override changes nothing except adding the footer.
- Link list and wording match the canonical footer on qutie.org (fetched live for reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)