### PR TITLE
Align family footer with the content column

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -32,6 +32,18 @@
     <div class="container">
       <section id="main_content">
         {{ content }}
+
+        <footer class="family-footer">
+          <div class="tagline">GOD DOES PLAY DICE. COME PLAY, BUILD, LEARN.</div>
+          <div><strong>Part of the Fun with Quantum family:</strong>
+            <a href="https://fun-with-quantum.org">Fun with Quantum</a> ·
+            <a href="https://rasqberry.org">RasQberry Two</a> ·
+            <a href="https://rasqberry.one">RasQberry One</a> ·
+            <a href="https://quantego.org">Quantego</a> ·
+            <a href="https://qutie.org">Qutie</a>
+          </div>
+          <div>Open source, built by <a href="https://www.linkedin.com/in/JanLahmann">Jan-R. Lahmann</a> and the RasQberry community.</div>
+        </footer>
       </section>
     </div>
 
@@ -40,7 +52,7 @@
         margin: 40px 0 20px;
         padding-top: 16px;
         border-top: 1px dashed #666;
-        text-align: center;
+        text-align: left;
         font-size: 13px;
         color: #999;
       }
@@ -51,16 +63,5 @@
         font-size: 12px;
       }
     </style>
-    <footer class="container family-footer">
-      <div class="tagline">GOD DOES PLAY DICE. COME PLAY, BUILD, LEARN.</div>
-      <div><strong>Part of the Fun with Quantum family:</strong>
-        <a href="https://fun-with-quantum.org">Fun with Quantum</a> ·
-        <a href="https://rasqberry.org">RasQberry Two</a> ·
-        <a href="https://rasqberry.one">RasQberry One</a> ·
-        <a href="https://quantego.org">Quantego</a> ·
-        <a href="https://qutie.org">Qutie</a>
-      </div>
-      <div>Open source, built by <a href="https://www.linkedin.com/in/JanLahmann">Jan-R. Lahmann</a> and the RasQberry community.</div>
-    </footer>
   </body>
 </html>


### PR DESCRIPTION
Follow-up to #49: the footer was centered in its own container and didn't line up with the text column above. It now lives inside #main_content (identical geometry) and is left-aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)