### PR TITLE
Add Umami analytics (shared family property)

### DIFF
--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,2 @@
+<!-- Umami analytics (shared Fun with Quantum family property) -->
+<script defer src="https://cloud.umami.is/script.js" data-website-id="97f347ac-e7ba-4be3-b26f-ab4b328bdbf2" data-domains="qoffee-maker.org"></script>


### PR DESCRIPTION
Adds cookieless Umami Cloud analytics via a new `_includes/head-custom.html`, which the existing `_layouts/default.html` already includes in `<head>`.

- Shared website ID across the Fun with Quantum family; per-site hostname filtering happens in the Umami dashboard.
- No cookies, so no consent banner is needed.
- `data-domains="qoffee-maker.org"` keeps localhost/preview traffic out of the stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)